### PR TITLE
Add debugging messaging for intermittent bug with sources

### DIFF
--- a/.remember/memory/self.md
+++ b/.remember/memory/self.md
@@ -1365,3 +1365,44 @@ flow is updated:
 6. ✅ Comprehensive test coverage for all components
 
 **Status**: Production-ready implementation with full test coverage confirming functionality.
+
+## Sources Not Displaying Bug Investigation - DEBUGGING ADDED
+
+**Problem**: Intermittent bug where chat responses return with no sources displayed in the frontend, even though sources should be available.
+
+**Root Analysis Completed**: Comprehensive code flow analysis from backend retrieval through frontend display identified 5 potential failure points.
+
+**Source Data Flow**:
+1. **Backend**: `makeChain` → `retrievalSequence` → `sendData({ sourceDocs: allDocuments })`
+2. **API**: Streamed via Server-Sent Events in `/api/chat/v1/route.ts`
+3. **Frontend**: `index.tsx` → `handleStreamingResponse` → processes with 100ms `setTimeout`
+4. **Display**: `SourcesList` component checks `sources.length > 0` before rendering
+
+**Five Theories Identified** (ranked by likelihood):
+
+1. **JSON Serialization/Parsing Failure**: Large sourceDocs arrays fail serialization or get corrupted during streaming
+2. **Timing Race Condition**: 100ms setTimeout in frontend processing loses sources if streaming completes too quickly
+3. **Browser Network Issues**: SSE chunks containing sourceDocs dropped due to network/browser issues  
+4. **makeChain Retrieval Silent Failure**: Document retrieval fails silently, returning empty arrays without proper logging
+5. **Frontend State Management Bug**: Sources received but not properly propagated through React state
+
+**Debugging Implementation**: Added comprehensive logging for top 2 theories:
+
+- **Backend** (`makeChain.ts`): Tests JSON serialization, logs payload sizes, detects silent failures
+- **SSE Layer** (`route.ts`): Validates JSON before transmission, monitors large payloads
+- **Frontend** (`index.tsx`): Tracks timing, validates data structure, logs state updates
+- **Component** (`SourcesList.tsx`): Monitors actual display rendering
+
+**Debug Markers**: All logs use consistent emoji prefixes for easy production filtering:
+- 🔍 = Debug info
+- ⚠️ = Warnings  
+- ❌ = Errors
+- ✅ = Success confirmations
+
+**Expected Production Evidence**:
+- **Theory #1**: Will show serialization errors, payload size warnings, round-trip failures
+- **Theory #2**: Will show timing mismatches between receive/process timestamps
+- **Silent failures**: Backend will log zero-document retrievals with question context
+- **Network issues**: Will show SSE transmission failures or missing frontend receipt logs
+
+**Status**: **DEBUGGING PHASE** - Comprehensive logging deployed to production for data collection and root cause identification.

--- a/package-lock.json
+++ b/package-lock.json
@@ -31999,6 +31999,60 @@
     "zod-to-json-schema": {
       "version": "3.24.5",
       "requires": {}
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.28.tgz",
+      "integrity": "sha512-kzGChl9setxYWpk3H6fTZXXPFFjg7urptLq5o5ZgYezCrqlemKttwMT5iFyx/p1e/JeglTwDFRtb923gTJ3R1w==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.28.tgz",
+      "integrity": "sha512-z6FXYHDJlFOzVEOiiJ/4NG8aLCeayZdcRSMjPDysW297Up6r22xw6Ea9AOwQqbNsth8JNgIK8EkWz2IDwaLQcw==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-gnu": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.28.tgz",
+      "integrity": "sha512-9ARHLEQXhAilNJ7rgQX8xs9aH3yJSj888ssSjJLeldiZKR4D7N08MfMqljk77fAwZsWwsrp8ohHsMvurvv9liQ==",
+      "optional": true
+    },
+    "@next/swc-linux-arm64-musl": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.28.tgz",
+      "integrity": "sha512-p6gvatI1nX41KCizEe6JkF0FS/cEEF0u23vKDpl+WhPe/fCTBeGkEBh7iW2cUM0rvquPVwPWdiUR6Ebr/kQWxQ==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.28.tgz",
+      "integrity": "sha512-nsiSnz2wO6GwMAX2o0iucONlVL7dNgKUqt/mDTATGO2NY59EO/ZKnKEr80BJFhuA5UC1KZOMblJHWZoqIJddpA==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-musl": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.28.tgz",
+      "integrity": "sha512-+IuGQKoI3abrXFqx7GtlvNOpeExUH1mTIqCrh1LGFf8DnlUcTmOOCApEnPJUSLrSbzOdsF2ho2KhnQoO0I1RDw==",
+      "optional": true
+    },
+    "@next/swc-win32-arm64-msvc": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.28.tgz",
+      "integrity": "sha512-l61WZ3nevt4BAnGksUVFKy2uJP5DPz2E0Ma/Oklvo3sGj9sw3q7vBWONFRgz+ICiHpW5mV+mBrkB3XEubMrKaA==",
+      "optional": true
+    },
+    "@next/swc-win32-ia32-msvc": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.28.tgz",
+      "integrity": "sha512-+Kcp1T3jHZnJ9v9VTJ/yf1t/xmtFAc/Sge4v7mVc1z+NYfYzisi8kJ9AsY8itbgq+WgEwMtOpiLLJsUy2qnXZw==",
+      "optional": true
+    },
+    "@next/swc-win32-x64-msvc": {
+      "version": "14.2.28",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.28.tgz",
+      "integrity": "sha512-1gCmpvyhz7DkB1srRItJTnmR2UwQPAUXXIg9r0/56g3O8etGmwlX68skKXJOp9EejW3hhv7nSQUJ2raFiz4MoA==",
+      "optional": true
     }
   }
 }

--- a/web/src/app/api/chat/v1/route.ts
+++ b/web/src/app/api/chat/v1/route.ts
@@ -713,10 +713,25 @@ async function handleChatRequest(req: NextRequest) {
                 }
               } catch (serializeError) {
                 console.error(`❌ SSE SOURCES ERROR: Failed to serialize SSE data:`, serializeError);
+                console.error(`❌ SSE SOURCES ERROR: This explains the bug - answer will stream but sources will fail`);
+                console.error(`❌ SSE SOURCES ERROR: Serialization error details:`, {
+                  name: serializeError.name,
+                  message: serializeError.message,
+                  sourceCount: data.sourceDocs?.length || 0
+                });
                 // Don't send sourceDocs if serialization fails
                 data = { ...data, sourceDocs: [] };
-                console.log(`🔍 SSE SOURCES DEBUG: Fallback - sending empty sources array`);
+                console.log(`🔍 SSE SOURCES DEBUG: Fallback - sending empty sources array, answer will still stream normally`);
               }
+            }
+            
+            // DEBUG: Log the sequence of sources vs answer streaming
+            if (data.sourceDocs && !data.token) {
+              console.log(`🔍 SSE TIMING DEBUG: Sending sources BEFORE answer streaming begins`);
+            } else if (data.token && !data.sourceDocs) {
+              // This is normal answer streaming - no need to log every token
+            } else if (data.token && data.sourceDocs) {
+              console.log(`🔍 SSE TIMING DEBUG: Unusual - sending both token and sources simultaneously`);
             }
             
             if (data.timing?.firstTokenGenerated && !timingMetrics.firstTokenGenerated) {

--- a/web/src/components/SourcesList.tsx
+++ b/web/src/components/SourcesList.tsx
@@ -64,6 +64,21 @@ const SourcesList: React.FC<SourcesListProps> = ({
   siteConfig,
   isSudoAdmin = false,
 }) => {
+  // DEBUG: Add logging for sources display debugging
+  React.useEffect(() => {
+    console.log(`🔍 SOURCELIST DEBUG: Component received ${sources.length} sources`);
+    if (sources.length === 0) {
+      console.log(`⚠️ SOURCELIST WARNING: No sources to display`);
+    } else {
+      console.log(`🔍 SOURCELIST DEBUG: First source:`, {
+        hasPageContent: !!sources[0]?.pageContent,
+        hasMetadata: !!sources[0]?.metadata,
+        type: sources[0]?.metadata?.type,
+        title: sources[0]?.metadata?.title
+      });
+    }
+  }, [sources]);
+
   // State hooks
   const [expandedSources, setExpandedSources] = useState<Set<number>>(new Set());
   const [showSourcesPopover, setShowSourcesPopover] = useState<boolean>(false);

--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -319,15 +319,35 @@ export default function Home({
 
       if (data.sourceDocs) {
         try {
+          // DEBUG: Add extensive logging for sources debugging
+          const receiveTimestamp = Date.now();
+          console.log(`🔍 FRONTEND SOURCES DEBUG: Received sourceDocs at ${receiveTimestamp}, type:`, typeof data.sourceDocs, 'isArray:', Array.isArray(data.sourceDocs));
+          
           setTimeout(() => {
+            const processTimestamp = Date.now();
+            const timeDiff = processTimestamp - receiveTimestamp;
+            console.log(`🔍 FRONTEND SOURCES DEBUG: Processing sourceDocs after ${timeDiff}ms delay`);
+            
             const immutableSourceDocs = Array.isArray(data.sourceDocs)
               ? [...data.sourceDocs]
               : [];
 
+            console.log(`🔍 FRONTEND SOURCES DEBUG: Processed ${immutableSourceDocs.length} sources`);
+
             if (immutableSourceDocs.length < sourceCount) {
               console.error(
-                `ERROR: Received ${immutableSourceDocs.length} sources, but ${sourceCount} were requested.`,
+                `❌ FRONTEND SOURCES ERROR: Received ${immutableSourceDocs.length} sources, but ${sourceCount} were requested.`,
               );
+            }
+
+            // DEBUG: Check if sources are properly structured
+            if (immutableSourceDocs.length > 0) {
+              const firstSource = immutableSourceDocs[0];
+              console.log(`🔍 FRONTEND SOURCES DEBUG: First source structure:`, {
+                hasPageContent: !!firstSource.pageContent,
+                hasMetadata: !!firstSource.metadata,
+                metadataKeys: firstSource.metadata ? Object.keys(firstSource.metadata) : 'none'
+              });
             }
 
             setSourceDocs(immutableSourceDocs);
@@ -335,9 +355,12 @@ export default function Home({
               accumulatedResponseRef.current,
               immutableSourceDocs,
             );
+            
+            console.log(`✅ FRONTEND SOURCES DEBUG: Successfully updated state with ${immutableSourceDocs.length} sources`);
           }, 100);
         } catch (error) {
-          console.error('Error handling sourceDocs:', error);
+          console.error('❌ FRONTEND SOURCES ERROR: Error handling sourceDocs:', error);
+          console.error('❌ FRONTEND SOURCES ERROR: Raw data.sourceDocs:', data.sourceDocs);
           // Fallback to empty array if parsing fails
           setSourceDocs([]);
           updateMessageState(accumulatedResponseRef.current, []);

--- a/web/src/utils/server/makechain.ts
+++ b/web/src/utils/server/makechain.ts
@@ -453,7 +453,40 @@ export const makeChain = async (
 
       // Send retrieved documents if sendData is available
       if (sendData) {
-        sendData({ sourceDocs: allDocuments });
+        // DEBUG: Add extensive logging for sources debugging
+        try {
+          console.log(`🔍 SOURCES DEBUG: Retrieved ${allDocuments.length} documents`);
+          
+          // Check for empty documents
+          if (allDocuments.length === 0) {
+            console.warn(`⚠️ SOURCES WARNING: No documents retrieved for question: "${input.question.substring(0, 100)}..."`);
+          }
+          
+          // Test JSON serialization before sending
+          const serializedTest = JSON.stringify(allDocuments);
+          const serializedSize = new Blob([serializedTest]).size;
+          console.log(`🔍 SOURCES DEBUG: Serialized sources size: ${serializedSize} bytes`);
+          
+          if (serializedSize > 1000000) { // 1MB threshold
+            console.warn(`⚠️ SOURCES WARNING: Large sources payload detected: ${serializedSize} bytes`);
+          }
+          
+          // Test if sources can be parsed back
+          const parseTest = JSON.parse(serializedTest);
+          if (!Array.isArray(parseTest) || parseTest.length !== allDocuments.length) {
+            console.error(`❌ SOURCES ERROR: Serialization round-trip failed!`);
+          } else {
+            console.log(`✅ SOURCES DEBUG: Serialization test passed`);
+          }
+          
+          sendData({ sourceDocs: allDocuments });
+          console.log(`✅ SOURCES DEBUG: Successfully sent ${allDocuments.length} sources to client`);
+          
+        } catch (serializationError) {
+          console.error(`❌ SOURCES ERROR: Failed to serialize/send sources:`, serializationError);
+          // Send empty array as fallback
+          sendData({ sourceDocs: [] });
+        }
       }
 
       // Resolve the document promise if resolveDocs is provided


### PR DESCRIPTION
Add comprehensive debugging to diagnose intermittent missing sources.

The bug causes sources to intermittently not display, while the answer text streams successfully. This suggests a failure specific to source transmission (e.g., JSON serialization) rather than general network issues. The added logs will pinpoint the exact failure point, with a focus on serialization errors and timing race conditions.