### PR TITLE
Fix sources list PDF download iOS

### DIFF
--- a/.remember/memory/self.md
+++ b/.remember/memory/self.md
@@ -178,3 +178,30 @@ for attr in tag.attrs:
         or attr.startswith("aria-")):
         del tag.attrs[attr]  # Remove attribute but keep the tag
 ```
+
+### 10. Mobile Safari Download Issues
+
+**Problem**: `window.open()` doesn't reliably trigger file downloads on mobile Safari (iPhone/iPad). The window opens but no download occurs.
+
+**Wrong**: Using `window.open()` for programmatic downloads.
+
+```typescript
+// Doesn't work on mobile Safari
+window.open(signedUrl, "_blank");
+```
+
+**Correct**: Create temporary link element with download attribute and programmatically click it.
+
+```typescript
+// Works reliably on mobile Safari
+const link = document.createElement("a");
+link.href = signedUrl;
+link.download = filename || "document.pdf";
+link.style.display = "none";
+
+document.body.appendChild(link);
+link.click();
+document.body.removeChild(link);
+```
+
+**Pattern**: For any programmatic file downloads, use the temporary link approach instead of `window.open()` to ensure mobile compatibility.

--- a/.remember/memory/self.md
+++ b/.remember/memory/self.md
@@ -205,3 +205,5 @@ document.body.removeChild(link);
 ```
 
 **Pattern**: For any programmatic file downloads, use the temporary link approach instead of `window.open()` to ensure mobile compatibility.
+
+**Cross-Browser Compatibility**: This fix works across all iOS browsers (Safari, Chrome, Firefox, Edge) because Apple requires all iOS browsers to use WebKit as their rendering engine. The programmatic link clicking approach with the `download` attribute is well-supported across WebKit-based browsers and specifically addresses mobile browser restrictions on programmatic window opening and file downloads.

--- a/web/src/components/SourcesList.tsx
+++ b/web/src/components/SourcesList.tsx
@@ -242,8 +242,17 @@ const SourcesList: React.FC<SourcesListProps> = ({
 
         const { signedUrl } = await response.json();
 
-        // Open the signed URL in a new tab to trigger download
-        window.open(signedUrl, "_blank");
+        // Create a temporary link element to trigger download
+        // This approach works reliably on mobile Safari (iPhone/iPad)
+        const link = document.createElement("a");
+        link.href = signedUrl;
+        link.download = doc.metadata.title || "document.pdf";
+        link.style.display = "none";
+        
+        // Append to document, click, then remove
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
       } catch (error) {
         console.error("Error downloading PDF:", error);
         // TODO: Show user-friendly error message


### PR DESCRIPTION
Fix PDF download button on iOS by using programmatic link click instead of `window.open()`.

The previous `window.open()` method did not reliably trigger file downloads on iOS browsers (Safari, Chrome, Firefox) due to WebKit restrictions. This PR implements a more robust solution by programmatically creating and clicking a temporary anchor tag with the `download` attribute, which is a standard and reliable method for initiating downloads on mobile devices.