### PR TITLE
test: Add testing section to verify Python CI workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -120,3 +120,7 @@ When Dependabot or similar tools create dependency update PRs, these workflows w
 - **Workflow runs:** GitHub Actions tab shows all runs and their status
 - **Notifications:** Failed runs will notify repository maintainers
 - **Trends:** Monitor build times and success rates over time
+
+## Testing
+
+This documentation was updated to test the Python CI workflows in our repository.


### PR DESCRIPTION
This change will trigger the Python CI workflow to test:
- Python 3.10, 3.11, 3.12 matrix execution
- Complete validation checklist
- Node.js linting and type checking
- Caching functionality