### PR TITLE
Fix Cursor development environment build/start reliability

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,47 +1,21 @@
-FROM ubuntu
+FROM python:3.11-bookworm
 
-# Install Python 3.11
-RUN apt-get update && apt-get install -y \
-    software-properties-common \
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    ca-certificates \
     curl \
     git \
-    && add-apt-repository ppa:deadsnakes/ppa \
-    && apt-get update \
-    && apt-get install -y \
-    python3.11 \
-    python3.11-dev \
-    python3.11-distutils \
-    python3.11-venv \
-    && apt-get clean \
+    gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pip for Python 3.11
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-
-# Install uv
+# Install uv globally so environment install scripts can use it immediately.
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
-# Set Python 3.11 as the default python3
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+# Cursor config uses user "ubuntu"; create it if missing.
+RUN id -u ubuntu >/dev/null 2>&1 || useradd -m -s /bin/bash ubuntu
 
-# Pre-install spaCy globally to speed up virtual environment setup
-RUN pip3 install spacy && python3 -m spacy download en_core_web_sm
+RUN python --version && pip --version && uv --version && node --version && npm --version
 
-# Install Node.js 20 using nvm in /opt to avoid root permission issues
-ENV NVM_DIR=/opt/nvm
-RUN mkdir -p $NVM_DIR \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | NVM_DIR=$NVM_DIR bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install 20 \
-    && nvm use 20 \
-    && nvm alias default 20
-
-# Add nvm and node to PATH for subsequent RUN commands
-ENV PATH="$NVM_DIR/versions/node/v20.*/bin:$PATH"
-    
-# Verify installation
-RUN . $NVM_DIR/nvm.sh && nvm use 20 && python3 --version && pip3 --version && uv --version && node --version && npm --version
-
-# Set environment variable for virtual environment path
-ENV PATH="/workspace/.venv/bin:$PATH"
+ENV PATH="/workspace/.venv/bin:/usr/local/bin:${PATH}"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -5,8 +5,8 @@
     "dockerfile": ".cursor/Dockerfile"
   },
   "user": "ubuntu",
-  "install": "export PATH=\"$HOME/.local/bin:/usr/local/bin:$PATH\" && export NVM_DIR=\"${NVM_DIR:-/opt/nvm}\" && if [ -s \"$NVM_DIR/nvm.sh\" ]; then . \"$NVM_DIR/nvm.sh\"; elif [ -s \"$HOME/.nvm/nvm.sh\" ]; then . \"$HOME/.nvm/nvm.sh\"; fi && if command -v nvm >/dev/null 2>&1; then nvm install 20 && nvm use 20 && nvm alias default 20; fi && node -e 'const major = Number(process.versions.node.split(\".\")[0]); if (major !== 20) { console.error(`Node 20 required, found ${process.versions.node}`); process.exit(1); }' && (command -v uv >/dev/null 2>&1 || curl -LsSf https://astral.sh/uv/install.sh | sh) && export PATH=\"$HOME/.local/bin:$PATH\" && uv sync --locked --package mega-rag-chatbot --package mega-rag-chatbot-crawler && cd /workspace/web && npm ci --workspace @mega-rag-chatbot/web --prefix /workspace && cd /workspace && touch .env.ananda && (grep -qxF 'export PATH=\"$HOME/.local/bin:/usr/local/bin:$PATH\"' ~/.bashrc || echo 'export PATH=\"$HOME/.local/bin:/usr/local/bin:$PATH\"' >> ~/.bashrc)",
-  "start": "export PATH=\"$HOME/.local/bin:/usr/local/bin:$PATH\" && export NVM_DIR=\"${NVM_DIR:-/opt/nvm}\" && if [ -s \"$NVM_DIR/nvm.sh\" ]; then . \"$NVM_DIR/nvm.sh\"; elif [ -s \"$HOME/.nvm/nvm.sh\" ]; then . \"$HOME/.nvm/nvm.sh\"; fi && if command -v nvm >/dev/null 2>&1; then nvm use 20 >/dev/null; fi && echo environment-ready",
+  "install": "node -e 'const major = Number(process.versions.node.split(\".\")[0]); if (major !== 20) { console.error(`Node 20 required, found ${process.versions.node}`); process.exit(1); }' && uv sync --locked --package mega-rag-chatbot --package mega-rag-chatbot-crawler && cd /workspace/web && npm ci --workspace @mega-rag-chatbot/web --prefix /workspace && cd /workspace && touch .env.ananda",
+  "start": "node -e 'const major = Number(process.versions.node.split(\".\")[0]); if (major !== 20) { console.error(`Node 20 required, found ${process.versions.node}`); process.exit(1); }' && echo environment-ready",
   "terminals": [],
   "repositoryDependencies": []
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Replaced `.cursor/Dockerfile` with a deterministic base image setup using `python:3.11-bookworm` and Node.js 20 from NodeSource.
- Removed fragile build-time steps (`deadsnakes` PPA, `nvm`, global spaCy model download) that can break cloud image builds.
- Simplified `.cursor/environment.json` install/start scripts to rely on image-provided Node/uv and keep strict Node 20 validation.

## Why
The previous environment bootstrap mixed multiple installation paths and network-heavy image-time tasks that are common failure points for cloud builds, which aligns with the reported "Failed to start the development environment" error.

## Validation performed
- Ran the environment `install` command end-to-end (uv sync + npm workspace install).
- Ran the environment `start` command and confirmed it prints `environment-ready`.
- Started the web app (`npm run dev ananda`) and confirmed Next.js reaches ready state on port 3000.
- Verified app response via `curl` and manual browser walkthrough.

## Walkthrough artifacts
[environment_setup_and_app_launch_demo.mp4](https://cursor.com/agents/bc-9c7a8c17-eb30-4b5a-bd47-2d36d6a1d514/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironment_setup_and_app_launch_demo.mp4)

[environment app loaded](https://cursor.com/agents/bc-9c7a8c17-eb30-4b5a-bd47-2d36d6a1d514/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenvironment_app_loaded.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c7a8c17-eb30-4b5a-bd47-2d36d6a1d514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c7a8c17-eb30-4b5a-bd47-2d36d6a1d514"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

