### PR TITLE
Configure Cursor Cloud canonical environment setup

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,47 +1,42 @@
-FROM ubuntu
+FROM ubuntu:22.04
 
-# Install Python 3.11
-RUN apt-get update && apt-get install -y \
-    software-properties-common \
-    curl \
-    git \
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install base packages and Python 3.11
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        git \
+        software-properties-common \
     && add-apt-repository ppa:deadsnakes/ppa \
     && apt-get update \
-    && apt-get install -y \
-    python3.11 \
-    python3.11-dev \
-    python3.11-distutils \
-    python3.11-venv \
-    && apt-get clean \
+    && apt-get install -y --no-install-recommends \
+        python3.11 \
+        python3.11-dev \
+        python3.11-distutils \
+        python3.11-venv \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1 \
+    && curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install pip for Python 3.11
-RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.11
-
-# Install uv
+# Install uv globally
 RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
 
-# Set Python 3.11 as the default python3
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1 \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3.11 1
+# Install Node.js 20 from NodeSource
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
-# Pre-install spaCy globally to speed up virtual environment setup
-RUN pip3 install spacy && python3 -m spacy download en_core_web_sm
+# Verify toolchain
+RUN python3 --version \
+    && pip3 --version \
+    && uv --version \
+    && node --version \
+    && npm --version
 
-# Install Node.js 20 using nvm in /opt to avoid root permission issues
-ENV NVM_DIR=/opt/nvm
-RUN mkdir -p $NVM_DIR \
-    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.0/install.sh | NVM_DIR=$NVM_DIR bash \
-    && . $NVM_DIR/nvm.sh \
-    && nvm install 20 \
-    && nvm use 20 \
-    && nvm alias default 20
-
-# Add nvm and node to PATH for subsequent RUN commands
-ENV PATH="$NVM_DIR/versions/node/v20.*/bin:$PATH"
-    
-# Verify installation
-RUN . $NVM_DIR/nvm.sh && nvm use 20 && python3 --version && pip3 --version && uv --version && node --version && npm --version
-
-# Set environment variable for virtual environment path
-ENV PATH="/workspace/.venv/bin:$PATH"
+# Prioritize project venv when present
+ENV PATH="/workspace/.venv/bin:${PATH}"

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,6 @@
+{
+  "build": {
+    "context": ".",
+    "dockerfile": ".cursor/Dockerfile"
+  }
+}

--- a/.github/workflows/monorepo-ci.yml
+++ b/.github/workflows/monorepo-ci.yml
@@ -32,7 +32,7 @@ jobs:
           node-version: "20"
           cache: "npm"
           cache-dependency-path: |
-            web/package-lock.json
+            package-lock.json
             web/package.json
 
       - name: Make helper scripts executable
@@ -50,8 +50,7 @@ jobs:
         run: ./bin/run-pip-audit.sh
 
       - name: Install Node.js dependencies
-        working-directory: ./web
-        run: npm ci
+        run: npm ci --workspace @mega-rag-chatbot/web --include-workspace-root
 
       - name: Validation Checklist
         run: |

--- a/web/__tests__/api/chat/v1/utils/streaming.ts
+++ b/web/__tests__/api/chat/v1/utils/streaming.ts
@@ -124,7 +124,6 @@ export function createMockStreamResponse(
     },
   });
 
-  // Cast the stream to any to avoid type incompatibilities between different ReadableStream implementations
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return new Response(stream as any, { status, headers });
+  // Response accepts BodyInit; cast through BodyInit to keep type safety and avoid `any`.
+  return new Response(stream as unknown as BodyInit, { status, headers });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Make Cursor Cloud use `.cursor/Dockerfile` as the canonical build source via `.cursor/environment.json`.
- Update `.cursor/Dockerfile` to consistently provision Python 3.11, Node 20, and `uv` with deterministic verification steps.
- Fix Monorepo CI Node install layout so `knip` can resolve `typescript` reliably.
- Remove an obsolete eslint-disable comment in `web/__tests__/api/chat/v1/utils/streaming.ts` that surfaced as a warning.

## Validation performed
- `uv sync` at repo root.
- `npm ci --workspace web` (initial environment check).
- `npm ci --workspace @mega-rag-chatbot/web --include-workspace-root` (CI-aligned install after workflow fix).
- Next.js dev-server smoke test (`npm run dev -- ananda` in `web/`) plus `curl -I http://127.0.0.1:3000` returning `HTTP/1.1 200 OK`.
- `cd web && npm run lint`.
- `cd web && npx tsc --noEmit`.
- `cd web && npm run knip -- --no-exit-code --reporter compact`.
- `cd web && npm run knip -- --include files,dependencies,unlisted,binaries,unresolved`.

## Artifacts
[nextjs_dev_server_smoke_test.mp4](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_dev_server_smoke_test.mp4)

[Next.js smoke test loaded page](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_smoke_loaded_page.webp)
[Next.js smoke test responsive scroll](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnextjs_smoke_scroll_responsive.webp)

[uv_sync.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fuv_sync.log)
[npm_ci_web.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnpm_ci_web.log)
[next_dev_curl_head.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnext_dev_curl_head.log)
[ci_fix_npm_ci.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_npm_ci.log)
[ci_fix_lint.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_lint.log)
[ci_fix_tsc.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_tsc.log)
[ci_fix_knip_compact.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_knip_compact.log)
[ci_fix_knip_blocking.log](https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fci_fix_knip_blocking.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08069d53-bb99-4f17-ac8e-375a6a3b1dee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

