### PR TITLE
fix(admin): preserve operator triage decision over pre-existing Notion task URL

### DIFF
--- a/web/__tests__/api/admin/downvoteFeedbackAction.test.ts
+++ b/web/__tests__/api/admin/downvoteFeedbackAction.test.ts
@@ -1,0 +1,204 @@
+import { createMocks } from "node-mocks-http";
+import type { NextApiRequest, NextApiResponse } from "next";
+
+// Mock firebase-admin for FieldValue.delete()/serverTimestamp() references in the handler
+jest.mock("firebase-admin", () => ({
+  __esModule: true,
+  default: {
+    firestore: {
+      FieldValue: {
+        delete: jest.fn(() => "__DELETE__"),
+        serverTimestamp: jest.fn(() => "__SERVER_TIMESTAMP__"),
+      },
+    },
+  },
+  firestore: {
+    FieldValue: {
+      delete: jest.fn(() => "__DELETE__"),
+      serverTimestamp: jest.fn(() => "__SERVER_TIMESTAMP__"),
+    },
+  },
+}));
+
+// Minimal Firestore mock: collection().doc() returns a reference object whose identity is preserved
+const answerRef = { __ref: "answer" };
+const eventRef = { __ref: "event" };
+
+let answerDocData: Record<string, any> = {};
+let eventDocData: Record<string, any> = {};
+
+jest.mock("@/services/firebase", () => ({
+  db: {
+    collection: jest.fn((name: string) => ({
+      doc: jest.fn(() => (name.includes("downvote_feedback_events") ? eventRef : answerRef)),
+      where: jest.fn(() => ({})),
+    })),
+  },
+}));
+
+jest.mock("@/utils/server/apiMiddleware", () => ({
+  withApiMiddleware: jest.fn((handler) => handler),
+}));
+
+jest.mock("@/utils/server/jwtUtils", () => ({
+  withJwtAuth: jest.fn((handler) => handler),
+}));
+
+jest.mock("@/utils/server/genericRateLimiter", () => ({
+  genericRateLimiter: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("@/utils/server/loadSiteConfig", () => ({
+  loadSiteConfigSync: jest.fn(() => ({ requireLogin: false })),
+}));
+
+jest.mock("@/utils/server/sudoCookieUtils", () => ({
+  getSudoCookie: jest.fn(() => ({ sudoCookieValue: "ok" })),
+}));
+
+jest.mock("@/utils/server/authz", () => ({
+  requireSuperuserRoleFromFirestore: jest.fn(),
+}));
+
+jest.mock("@/utils/server/firestoreUtils", () => ({
+  getAnswersCollectionName: jest.fn(() => "answers"),
+  getDownvoteFeedbackEventsCollectionName: jest.fn(() => "downvote_feedback_events"),
+}));
+
+jest.mock("@/utils/server/firestoreRetryUtils", () => ({
+  firestoreGet: jest.fn(),
+  firestoreQueryGet: jest.fn(),
+  firestoreUpdate: jest.fn(),
+}));
+
+jest.mock("@/utils/server/downvoteFeedbackService", () => ({
+  DownvoteFeedbackService: {
+    buildClusters: jest.fn(() => []),
+    toIsoString: jest.fn(() => ""),
+  },
+}));
+
+jest.mock("@/utils/server/notionTaskClient", () => ({
+  NotionTaskClient: jest.fn().mockImplementation(() => ({
+    isConfigured: jest.fn(() => true),
+    findReusableTask: jest.fn(() => undefined),
+    createDraftTask: jest.fn(() => undefined),
+  })),
+}));
+
+jest.mock("@/utils/server/errorSanitization", () => ({
+  getSafeErrorMessage: jest.fn((_err, fallback) => fallback),
+}));
+
+import handler from "@/pages/api/admin/downvoteFeedbackAction";
+
+describe("/api/admin/downvoteFeedbackAction", () => {
+  const firestoreRetryUtils = jest.requireMock("@/utils/server/firestoreRetryUtils");
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    answerDocData = { feedbackEventId: "event-123" };
+    eventDocData = {};
+
+    firestoreRetryUtils.firestoreGet.mockImplementation((ref: any) => {
+      if (ref === answerRef) {
+        return Promise.resolve({ exists: true, data: () => answerDocData });
+      }
+      return Promise.resolve({ exists: true, data: () => eventDocData });
+    });
+    firestoreRetryUtils.firestoreUpdate.mockResolvedValue(undefined);
+  });
+
+  it("closes event as ignored when operator picks no_action, even if event has an existing notionTaskUrl", async () => {
+    // Event was previously routed to a Notion task; operator now chooses Close - no action.
+    eventDocData = {
+      taskCandidateKey: "abc",
+      notionTaskUrl: "https://notion.so/previously-linked-task",
+      notionTaskId: "notion-id-1",
+      triageStatus: "task_created",
+    };
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: {
+        answerDocId: "answer-1",
+        operatorDecision: "no_action",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+
+    // First firestoreUpdate is the event doc, second is the answer doc
+    const calls = firestoreRetryUtils.firestoreUpdate.mock.calls;
+    expect(calls.length).toBe(2);
+
+    const [eventUpdateRef, eventUpdatePayload] = calls[0];
+    const [answerUpdateRef, answerUpdatePayload] = calls[1];
+
+    expect(eventUpdateRef).toBe(eventRef);
+    expect(answerUpdateRef).toBe(answerRef);
+
+    // Bug: current code overrides triageStatus back to "task_created" because the
+    // event still has a notionTaskUrl, which contradicts the operator's explicit decision.
+    expect(eventUpdatePayload.triageStatus).toBe("ignored");
+    expect(eventUpdatePayload.operatorDecision).toBe("no_action");
+    expect(answerUpdatePayload.feedbackTriageStatus).toBe("ignored");
+    expect(answerUpdatePayload.feedbackOperatorDecision).toBe("no_action");
+  });
+
+  it("marks event as reviewed when operator picks accept without linking a task, even if event has an existing notionTaskUrl", async () => {
+    // Operator uses "Reviewed - no task" on an event that was previously linked.
+    eventDocData = {
+      taskCandidateKey: "abc",
+      notionTaskUrl: "https://notion.so/previously-linked-task",
+      notionTaskId: "notion-id-1",
+      triageStatus: "task_created",
+    };
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: {
+        answerDocId: "answer-1",
+        operatorDecision: "accept",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+
+    const calls = firestoreRetryUtils.firestoreUpdate.mock.calls;
+    expect(calls.length).toBe(2);
+    const [, eventUpdatePayload] = calls[0];
+    const [, answerUpdatePayload] = calls[1];
+
+    expect(eventUpdatePayload.triageStatus).toBe("reviewed");
+    expect(answerUpdatePayload.feedbackTriageStatus).toBe("reviewed");
+  });
+
+  it("still records task_created when operator explicitly links a new Notion task via body", async () => {
+    eventDocData = { taskCandidateKey: "abc" };
+
+    const { req, res } = createMocks<NextApiRequest, NextApiResponse>({
+      method: "POST",
+      body: {
+        answerDocId: "answer-1",
+        operatorDecision: "accept",
+        notionTaskUrl: "https://notion.so/new-link",
+      },
+    });
+
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(200);
+    const calls = firestoreRetryUtils.firestoreUpdate.mock.calls;
+    const [, eventUpdatePayload] = calls[0];
+    const [, answerUpdatePayload] = calls[1];
+    expect(eventUpdatePayload.triageStatus).toBe("task_created");
+    expect(eventUpdatePayload.notionTaskUrl).toBe("https://notion.so/new-link");
+    expect(answerUpdatePayload.feedbackTriageStatus).toBe("task_created");
+    expect(answerUpdatePayload.feedbackNotionTaskUrl).toBe("https://notion.so/new-link");
+  });
+});

--- a/web/src/pages/api/admin/downvoteFeedbackAction.ts
+++ b/web/src/pages/api/admin/downvoteFeedbackAction.ts
@@ -148,9 +148,18 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const eventUpdates: Record<string, unknown> = {};
     const answerUpdates: Record<string, unknown> = {};
 
+    // A newly created/reused Notion task from this request should drive triageStatus.
+    // A pre-existing notionTaskUrl on the event must NOT override an explicit operator
+    // decision like "no_action" (Close) or "accept" (Reviewed - no task).
+    const createdOrReusedNotionUrl = createNotionTask === true ? linkedNotionUrl : undefined;
+    const providedNotionUrl =
+      typeof notionTaskUrl === "string" && notionTaskUrl.trim() ? notionTaskUrl.trim() : undefined;
+    const appliedNotionUrl = createdOrReusedNotionUrl || providedNotionUrl;
+    const appliedNotionId = createdOrReusedNotionUrl ? linkedNotionId : undefined;
+
     if (operatorDecision !== undefined) {
       const nextTriageStatus =
-        operatorDecision === "no_action" ? "ignored" : linkedNotionUrl ? "task_created" : "reviewed";
+        operatorDecision === "no_action" ? "ignored" : appliedNotionUrl ? "task_created" : "reviewed";
       eventUpdates.operatorDecision = operatorDecision;
       eventUpdates.operatorReviewedAt = firebase.firestore.FieldValue.serverTimestamp();
       eventUpdates.triageStatus = nextTriageStatus;
@@ -162,11 +171,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       eventUpdates.operatorNote = operatorNote.trim();
     }
 
-    if (linkedNotionUrl) {
-      eventUpdates.notionTaskUrl = linkedNotionUrl;
-      eventUpdates.notionTaskId = linkedNotionId || firebase.firestore.FieldValue.delete();
+    if (appliedNotionUrl) {
+      eventUpdates.notionTaskUrl = appliedNotionUrl;
+      eventUpdates.notionTaskId = appliedNotionId || firebase.firestore.FieldValue.delete();
       eventUpdates.triageStatus = "task_created";
-      answerUpdates.feedbackNotionTaskUrl = linkedNotionUrl;
+      answerUpdates.feedbackNotionTaskUrl = appliedNotionUrl;
       answerUpdates.feedbackTriageStatus = "task_created";
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Scanned recent commits for bugs. Found a high-confidence issue introduced in commit `8106b23f` ("feat: update downvote feedback workflow and enhance related components") in `web/src/pages/api/admin/downvoteFeedbackAction.ts`.

## Bug

`linkedNotionUrl` was seeded from the event's existing `notionTaskUrl` field:

```ts
let linkedNotionUrl =
  typeof notionTaskUrl === "string" && notionTaskUrl.trim() ? notionTaskUrl.trim() : eventData.notionTaskUrl;
```

Then later, the handler unconditionally overrode `triageStatus` whenever `linkedNotionUrl` was truthy:

```ts
if (linkedNotionUrl) {
  eventUpdates.triageStatus = "task_created";
  answerUpdates.feedbackTriageStatus = "task_created";
}
```

So once a feedback event had been previously routed to Notion, the admin's "Close - no action" and "Reviewed - no task" buttons on `/admin/downvotes` silently reverted the event (and its answer mirror) back to `task_created`, instead of recording `ignored` or `reviewed`. The `operatorDecision` field was still written, but the triage status that drives the admin queue filter was wrong, so the item stayed "resolved to task board" in the UI and in downstream routing.

## Fix

Only let this request's created/reused Notion task (via `createNotionTask === true`) or an explicitly provided `notionTaskUrl` in the request body drive the `task_created` override. A stale `eventData.notionTaskUrl` can no longer mask the operator's explicit decision.

```ts
const createdOrReusedNotionUrl = createNotionTask === true ? linkedNotionUrl : undefined;
const providedNotionUrl =
  typeof notionTaskUrl === "string" && notionTaskUrl.trim() ? notionTaskUrl.trim() : undefined;
const appliedNotionUrl = createdOrReusedNotionUrl || providedNotionUrl;
const appliedNotionId = createdOrReusedNotionUrl ? linkedNotionId : undefined;
```

## Reproduction

Added `web/__tests__/api/admin/downvoteFeedbackAction.test.ts` with three cases:

1. Event has existing `notionTaskUrl`; operator picks `no_action` → expect `triageStatus = ignored` and `feedbackTriageStatus = ignored` (failed before fix; passes after).
2. Event has existing `notionTaskUrl`; operator picks `accept` without linking → expect `triageStatus = reviewed` and `feedbackTriageStatus = reviewed` (failed before fix; passes after).
3. Operator explicitly provides `notionTaskUrl` in the request body → still records `task_created` and writes the new Notion URL (passes before and after fix — regression guard).

Pre-fix run against the same test file:

```
✕ closes event as ignored when operator picks no_action, even if event has an existing notionTaskUrl
    Expected: "ignored"
    Received: "task_created"

✕ marks event as reviewed when operator picks accept without linking a task, even if event has an existing notionTaskUrl
    Expected: "reviewed"
    Received: "task_created"

✓ still records task_created when operator explicitly links a new Notion task via body
```

Post-fix: all three pass.

## Testing

- `npx jest __tests__/api/admin/downvoteFeedbackAction.test.ts` — 3/3 new tests pass
- `npx jest __tests__/api/admin/` — 19 suites, 223 pass, 1 skipped
- `npx jest` (full client suite) — 140 suites, 1572 pass, 92 skipped
- `SECRET_KEY=test-secret npx jest --selectProjects=server` — 42 suites, 843 pass, 4 skipped
- `npx eslint` on changed files — clean

## Risk / Scope

- Minimal behavior change: only the branch that forces `task_created` is narrowed. The response payload (`notionTaskUrl: linkedNotionUrl || null`) is unchanged for compatibility with the existing `DownvotedAnswerReview` client.
- No DB schema or public API changes.
- Behavior for the normal "Send to task board" flow (`createNotionTask === true`) is identical to before.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e408b4c-ac47-47af-9a32-dcb9ada16442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e408b4c-ac47-47af-9a32-dcb9ada16442"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

