### PR TITLE
chore(npmrc): set min-release-age to 604800 (seconds, = 7 days)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,4 @@
-min-release-age=7
+min-release-age=604800
 # Use legacy peer deps resolution to handle transitive peer dependency conflicts
 # (e.g., @browserbasehq/stagehand requiring openai@^4.x while project uses openai@6.x)
 legacy-peer-deps=true

--- a/.remember/memory/self.md
+++ b/.remember/memory/self.md
@@ -2,6 +2,31 @@
 
 ## Critical Lessons Learned
 
+### npm `min-release-age` Is Seconds, Not Days
+
+**Rule**: The `.npmrc` `min-release-age` setting is interpreted by npm in **seconds**, not days. Writing `7` allows
+any package at least 7 seconds old, silently disabling the install-time cooldown. uv's `exclude-newer = "7 days"`
+accepts a duration string, which is the easy source of the confusion.
+
+**Wrong**:
+
+```ini
+# .npmrc
+min-release-age=7
+```
+
+**Correct**:
+
+```ini
+# .npmrc
+min-release-age=604800   # 7 * 24 * 3600
+```
+
+**Sequencing when fixing**: before flipping the value, verify no package currently in `package-lock.json` was
+published inside the new window (look up `time` for each suspect at `https://registry.npmjs.org/<pkg>`); also hold
+any open Dependabot npm PR whose proposed versions are inside the window — once strict cooldown is in place,
+those PRs' `npm ci` will fail until the packages age out, which is the desired behavior but should be expected.
+
 ### Rate Limiter Fail-Closed Must Send A Response
 
 **Wrong**: Return `false` from an API rate limiter after a backend failure without writing to `NextApiResponse`; callers


### PR DESCRIPTION
## Summary

- npm interprets `min-release-age` as **seconds**, not days. The previous `.npmrc` value `7` allowed any package at least 7 seconds old, effectively disabling the install-time cooldown — `cooldown_audit.py` was the only thing enforcing the policy on the Node side.
- Bumps `.npmrc` to `min-release-age=604800` (7 × 24 × 3600) so `npm ci` enforces the same 7-day cooldown that `uv` (`exclude-newer = "7 days"`) and `cooldown_audit.py` already enforce.

## Why this is safe to merge today

The original task (drafted 2026-04-19) deferred this fix until 2026-04-23 because the lockfile then held two packages still inside cooldown. Both have aged out by ~3 weeks:

| Lockfile entry | Published | Age today | Past 7-day cooldown? |
| --- | --- | --- | --- |
| `dompurify@3.4.0` | 2026-04-14 | 28d | yes |
| `next@16.2.4` | 2026-04-15 | 27d | yes |
| `fast-xml-parser@5.7.2` (most recent lockfile change) | 2026-04-24 | 18d | yes |

## Sequencing note re: open Dependabot PR #110

Dependabot PR #110 wants to land:

- `fast-uri@3.1.2` — published 2026-05-05, ages out today
- `fast-xml-builder@1.2.0` — published 2026-05-08, ages out **2026-05-15**

Once this `.npmrc` PR merges, #110's `npm ci` will (correctly) start failing on `fast-xml-builder@1.2.0` until 2026-05-15. That is the desired behavior and confirms the fix is enforcing. PR #110 should be rebased and merged on/after 2026-05-15.

## Test plan

- [ ] `Monorepo CI (Python 3.11)` passes on this PR
- [ ] `Comprehensive Test Suite` passes on this PR
- [ ] Local: `rm -rf node_modules && npm ci` succeeds from a clean install
- [ ] Negative test: `npm install <pkg>@<version-published-today>` is refused with a `min-release-age` error; revert the test install
- [ ] Merge
