### PR TITLE
deps: bump fast-uri 3.1.0 -> 3.1.2 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10592,9 +10592,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary

Cherry-picks the **fast-uri 3.1.0 → 3.1.2** portion of Dependabot PR #110, leaving the `fast-xml-builder` bump in #110 to age past the 7-day cooldown.

## Why now

fast-uri 3.1.2 is an upstream **security release** ([release notes](https://github.com/fastify/fast-uri/releases/tag/v3.1.2)):

- Fix for [GHSA-v39h-62p7-jpjc](https://github.com/fastify/fast-uri/security/advisories/GHSA-v39h-62p7-jpjc) — handle malformed fragment decoding as a parse error
- Includes the prior 3.1.1 fix for [GHSA-q3j6-qgpj-74h6](https://github.com/fastify/fast-uri/security/advisories/GHSA-q3j6-qgpj-74h6)

Published 2026-05-05; **7+ days old** as of merge-time (2026-05-12), satisfying the project's 7-day cooldown discipline.

`fast-xml-builder@1.2.0` (the other bump in #110) was published 2026-05-08 and won't age out until 2026-05-15, so it's deliberately left behind in #110.

## Diff scope

Lockfile-only, three lines — `version`, `resolved`, `integrity` for the `node_modules/fast-uri` block. fast-uri 3.1.2 is a leaf package (`dependencies: {}`, `engines: {}`), so no transitive metadata changes are needed.

`fast-uri` enters the tree as a transitive `dev` dependency (via `ajv` used by jest/eslint/json-schema validation) — not in production code paths.

## Test plan

- [ ] CI: `Monorepo CI (Python 3.11)` passes
- [ ] CI: `Comprehensive Test Suite` passes
- [ ] CI: `cooldown_audit.py` (node) shows fast-uri advisory cleared
- [ ] Merge

## Follow-ups

- After 2026-05-15: rebase #110 (now reduced to just `fast-xml-builder@1.2.0`) and merge.
