### PR TITLE
fix: make chatbot.js delay-proof for JS-delay optimizers (FlyingPress)

### DIFF
--- a/wordpress/plugins/ananda-ai-chatbot/assets/js/chatbot.js
+++ b/wordpress/plugins/ananda-ai-chatbot/assets/js/chatbot.js
@@ -20,7 +20,12 @@
  * - AI suggestion chips for follow-up questions
  */
 
-document.addEventListener("DOMContentLoaded", () => {
+function initChatbot() {
+  // A JS-delay optimizer (e.g. FlyingPress) can replay this script; never
+  // initialize twice or we'd build duplicate UI and event listeners.
+  if (window.aichatbotInitialized) return;
+  window.aichatbotInitialized = true;
+
   // API endpoint paths
   const API_PATHS = {
     CHAT: "/api/chat/v1",
@@ -1162,6 +1167,13 @@ document.addEventListener("DOMContentLoaded", () => {
   async function sendMessage() {
     const message = input.value.trim();
     if (!message) return;
+
+    // Auth module loads first as a hard dependency, but guard against any delay
+    // race so we fail cleanly before mutating the UI rather than throwing mid-send.
+    if (!window.aichatbotAuth || typeof getToken !== "function") {
+      console.error("[Ananda-AI-Chatbot]: Auth module not ready.");
+      return;
+    }
 
     // Test functionality: if message is exactly "hi, this is michel sampil vaitikaitis", trigger error and send email
     if (message === "hi, this is michel sampil vaitikaitis") {
@@ -2578,10 +2590,16 @@ document.addEventListener("DOMContentLoaded", () => {
     bubble.classList.remove("magnetic-ripple-animation-big");
   }
 
-  // Call startAttentionAnimation when the page loads, after bubble is created
-  window.addEventListener("load", () => {
+  // Call startAttentionAnimation when the page loads, after bubble is created.
+  // Guard against a delay optimizer replaying this script after the load event
+  // has already fired (in which case the listener would never run).
+  if (document.readyState === "complete") {
     setTimeout(startAttentionAnimation, 1000); // Small delay to ensure bubble is rendered
-  });
+  } else {
+    window.addEventListener("load", () => {
+      setTimeout(startAttentionAnimation, 1000); // Small delay to ensure bubble is rendered
+    });
+  }
 
   // Stop animation when window is opened, restart when closed
   function setupAnimationToggle() {
@@ -2776,4 +2794,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Initialize search bubble functionality
   initSearchBubble();
-});
+}
+
+// Initialize defensively so the chatbot works even when a JS-delay optimizer
+// (e.g. FlyingPress) replays this script after DOMContentLoaded has fired.
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initChatbot);
+} else {
+  initChatbot();
+}


### PR DESCRIPTION
## Problem

The entire `chatbot.js` body was wrapped in a single `document.addEventListener("DOMContentLoaded", …)`. A JS-delay optimizer (FlyingPress, used by the *Ananda.org — Speed Optimization 2026* effort) defers scripts until user interaction and then **replays** them — usually *after* `DOMContentLoaded` has already fired. A listener registered at replay time never runs, so the chatbot silently fails to initialize.

Asana: [1215640671886874](https://app.asana.com/1/915905600236/project/1214940686680883/task/1215640671886874)

## Fix

Stop depending on the `DOMContentLoaded` event — run init immediately if the DOM is already parsed, otherwise wait for the event. This mirrors the order-independent pattern already used by `setupAnimationToggle` at the bottom of the same file.

Changes to `wordpress/plugins/ananda-ai-chatbot/assets/js/chatbot.js` (+31/−5):

1. **Main wrapper** → extracted into `function initChatbot()` with a `readyState` gate (`loading` → wait for `DOMContentLoaded`; otherwise run now).
2. **Idempotency guard** at the top of `initChatbot` so a replay can't build duplicate UI/listeners.
3. **Attention-animation `load` listener** → same `readyState === "complete"` gate so it fires even if `load` already passed.
4. **`sendMessage` auth guard** — fails cleanly before mutating the UI if the auth global isn't ready.

## Why it's safe

- `chatbot-auth.js` is already delay-safe (top-level `window.aichatbotAuth` + IIFE), enqueued first as a hard dependency, with `aichatbotData` localized onto the auth handle.
- The chatbot markup is server-rendered via `aichatbot_add_chat_bubble()` on the `wp_footer` hook, so the DOM elements always exist before any script (delayed or not) runs.
- The diff is a pure wrap: the ~2,750-line body is byte-identical with no re-indentation.

## Verification

- ✅ `node --check` passes (braces/parens balance)
- ✅ Pure-wrap confirmed via diff; added lines match prettier (project config)
- ⏳ **Functional (needs staging w/ FlyingPress):** with delay on, interact with a page and confirm the bubble initializes — `!!document.getElementById("aichatbot-controls")` returns `true` in the console — then send a message to confirm auth/streaming. Confirm no regression with delay off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)