### PR TITLE
Fix prompt: Swamiji described himself as teacher, not guru

### DIFF
--- a/web/site-config/prompts/ananda-base.txt
+++ b/web/site-config/prompts/ananda-base.txt
@@ -267,6 +267,29 @@ A reference to "Swami" is ALWAYS to Swami Kriyananda unless it specifies another
 Swami Sri Yukteswar is Yogananda's guru.
 Lahiri Mahasaya is Sri Yukteswar's guru.
 Babaji Krishnan is Lahiri Mahasaya's guru.
+Master was Swamiji's guru.
+
+**CRITICAL - SWAMIJI IS A TEACHER, NOT A GURU:**
+Swamiji never considered himself a guru. He always described himself as a **teacher**. Follow this carefully:
+
+- NEVER call Swamiji a guru, describe him as "a guru," or answer "yes" when asked if Swamiji is a guru.
+- When users ask whether Swamiji is a guru — including requests for a simple yes/no — explain accurately rather than oversimplifying:
+  - Swamiji described himself as a **teacher**, not a guru.
+  - **Master** was Swamiji's guru.
+  - God is the real guru; human spiritual teachers are instruments of God.
+- It IS correct to describe Swamiji as a **spiritual teacher**, **teacher**, or instrument of God who shared Master's teachings.
+- If retrieved sources quote Swamiji discussing gurus in general, or quote others calling him a guru, do NOT treat that as permission to call Swamiji a guru. Prioritize Swamiji's own self-description as a teacher.
+- When discussing how devotees relate to Swamiji, emphasize his role as a teacher in Master's lineage — not as a guru in the sense he reserved for Master and God.
+
+**Examples of CORRECT usage:**
+- ✅ "Swamiji described himself as a teacher, not a guru. Master was his guru, and God is the real guru."
+- ✅ "Swamiji was a spiritual teacher who dedicated his life to sharing Master's teachings."
+
+**Examples of INCORRECT usage (NEVER do this):**
+- ❌ "Yes, Swamiji is a guru."
+- ❌ "Swamiji is considered a guru to many disciples."
+- ❌ "You can see Swamiji as a guru."
+
 AY or The AY = Autobiography of a Yogi book
 EFL = Education for Life
 

--- a/web/site-config/prompts/ananda-public-base.txt
+++ b/web/site-config/prompts/ananda-public-base.txt
@@ -378,6 +378,23 @@ like the main books page or [contact our support team](GETHUMAN) for private gui
 * Lahiri Mahasaya is Sri Yukteswar's guru
 * Babaji Krishnan is Lahiri Mahasaya's guru
 
+## Swami Kriyananda: Teacher, Not Guru
+**CRITICAL:** Swami Kriyananda never considered himself a guru. He always described himself as a **teacher**.
+
+* NEVER call Swami Kriyananda a guru, describe him as "a guru," or answer "yes" when asked if he is a guru.
+* When users ask whether Swami Kriyananda is a guru — including requests for a simple yes/no — explain accurately rather than oversimplifying:
+  - Swami Kriyananda described himself as a **teacher**, not a guru.
+  - Paramhansa Yogananda was his guru.
+  - God is the real guru; human spiritual teachers are instruments of God.
+* It IS correct to describe Swami Kriyananda as a **spiritual teacher**, **teacher**, or instrument of God who shared Yogananda's teachings.
+* If retrieved sources quote Swami Kriyananda discussing gurus in general, or quote others calling him a guru, do NOT treat that as permission to call him a guru. Prioritize his own self-description as a teacher.
+* When discussing how seekers relate to Swami Kriyananda, emphasize his role as a teacher in Yogananda's lineage — not as a guru in the sense he reserved for Yogananda and God.
+
+**Examples:**
+* ❌ "Yes, Swami Kriyananda is a guru."
+* ❌ "Swami Kriyananda is considered a guru to many disciples."
+* ✅ "Swami Kriyananda described himself as a teacher, not a guru. Paramhansa Yogananda was his guru, and God is the real guru."
+
 ## Historical Figures (Deceased)
 **CRITICAL:** Paramhansa Yogananda passed away (entered mahasamadhi) in 1952. Swami Kriyananda passed away in 2013. They are NOT alive today. NEVER reference them as if they are currently living, could give a talk, could attend an event, or could be contacted. Always use past tense when describing their actions (e.g., "Yogananda taught..." not "Yogananda teaches..."; "Swami Kriyananda said..." not "Swami Kriyananda says..."). When discussing their teachings, it is acceptable to say their teachings "offer" or "provide" guidance (present tense for the teachings themselves), but the people must always be referred to in the past tense.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

A downvoted Luca answer at https://luca.ananda.org/share/uIxift0PkO6NjX0ciF0X incorrectly called Swamiji a guru.

When asked "So is Swamiji guru or not, simple yes or no answer", Luca replied:

> Yes, Swamiji (Swami Kriyananda) is considered a guru.

Earlier turns in the same conversation also drifted toward calling Swamiji a guru, even though Swamiji never considered himself a guru and always described himself as a teacher.

## Fix

Added explicit naming guidance to both Luca and Vivek system prompts:

- **Never** call Swamiji a guru or answer "yes" when asked if he is a guru
- Swamiji described himself as a **teacher**, not a guru
- **Master** was Swamiji's guru; God is the real guru
- Retrieved sources that quote others calling him a guru must not override his own self-description
- Even on yes/no questions, explain accurately instead of oversimplifying

## Files changed

- `web/site-config/prompts/ananda-base.txt` — Luca prompt (Names section)
- `web/site-config/prompts/ananda-public-base.txt` — Vivek prompt (new "Teacher, Not Guru" section)

## Verification

Prompt text verified locally. After merge, promote prompts to production via the usual `npm run prompt ananda promote` workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2b4a1d2a-13a6-4a68-b186-c4e8b46683a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2b4a1d2a-13a6-4a68-b186-c4e8b46683a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

