### PR TITLE
fix: hide follow-up pills for location queries

### DIFF
--- a/web/src/utils/server/makechain.ts
+++ b/web/src/utils/server/makechain.ts
@@ -1884,9 +1884,18 @@ export async function setupAndExecuteLanguageModelChain(
 
       sendData({ done: true, timing: finalTiming });
 
-      // Task conversations use task follow-up chips; skip AI follow-up pill generation.
+      // Task conversations use task follow-up chips; location queries skip Go deeper/broader/daily-life pills.
       let suggestionsPromise: Promise<TypedSuggestion[]> = Promise.resolve([]);
-      if (!taskMode) {
+      let skipFollowUpSuggestionsForLocation = false;
+      if (siteConfig?.enableGeoAwareness && sanitizedQuestion) {
+        try {
+          skipFollowUpSuggestionsForLocation = await hasLocationIntentAsync(sanitizedQuestion);
+        } catch (error) {
+          console.warn("Failed to check location intent for follow-up suppression:", error);
+        }
+      }
+
+      if (!taskMode && !skipFollowUpSuggestionsForLocation) {
         if (timingMetrics) {
           timingMetrics.suggestionsGenerationStart = Date.now();
         }

--- a/web/src/utils/server/makechain.ts
+++ b/web/src/utils/server/makechain.ts
@@ -1526,6 +1526,13 @@ export async function setupAndExecuteLanguageModelChain(
   while (retryCount < MAX_RETRIES) {
     try {
       streamingDeadline.reset();
+      let isLocationQuery = false;
+      const trackStreamingData = (data: StreamingResponseData) => {
+        if (data.isLocationQuery) {
+          isLocationQuery = true;
+        }
+        sendData(data);
+      };
       const modelName = modelOverride || siteConfig?.modelName || "gpt-4o";
       const temperature = siteConfig?.temperature || 0.3;
       const rephraseModelName = "gpt-4.1-mini";
@@ -1564,7 +1571,7 @@ export async function setupAndExecuteLanguageModelChain(
         { model: modelName, temperature },
         sourceCount,
         filter,
-        sendData,
+        trackStreamingData,
         undefined,
         { model: rephraseModelName, temperature: rephraseTemperature },
         temporarySession,
@@ -1886,16 +1893,7 @@ export async function setupAndExecuteLanguageModelChain(
 
       // Task conversations use task follow-up chips; location queries skip Go deeper/broader/daily-life pills.
       let suggestionsPromise: Promise<TypedSuggestion[]> = Promise.resolve([]);
-      let skipFollowUpSuggestionsForLocation = false;
-      if (siteConfig?.enableGeoAwareness && sanitizedQuestion) {
-        try {
-          skipFollowUpSuggestionsForLocation = await hasLocationIntentAsync(sanitizedQuestion);
-        } catch (error) {
-          console.warn("Failed to check location intent for follow-up suppression:", error);
-        }
-      }
-
-      if (!taskMode && !skipFollowUpSuggestionsForLocation) {
+      if (!taskMode && !isLocationQuery) {
         if (timingMetrics) {
           timingMetrics.suggestionsGenerationStart = Date.now();
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Location queries (e.g. "centers near London", "Ananda centers in India") no longer show the **Go deeper**, **Go broader**, or **Take into daily life** follow-up suggestion lanes after the answer.

## Why

Location answers are practical directory lookups. Spiritual follow-up pills are distracting and often irrelevant in that context.

## Implementation

Reuses the existing `isLocationQuery` flag that `makeChain` already sets during geo-awareness retrieval. A lightweight stream wrapper records `{ isLocationQuery: true }` when emitted, and follow-up pill generation is skipped — **no second `hasLocationIntentAsync` call** and no extra embeddings API round trip.

## Testing

- Server tests: `makechain.test.ts`, `generateFollowUpSuggestions.test.ts`
- Lint-staged: TypeScript, ESLint, and related Jest checks passed on commit
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7aef563d-2c21-4544-91d1-89c805b66111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7aef563d-2c21-4544-91d1-89c805b66111"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

