### PR TITLE
chore(deps): bump nltk to 3.10.0 (aged-in security)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "multiprocess==0.70.18",
     "mutagen==1.47.0",
     "networkx==3.4.2",
-    "nltk==3.9.4",
+    "nltk==3.10.0",
     "numpy>=2.0,<3.0",
     "openai>=2.20.0",
     "openpyxl==3.1.5",

--- a/requirements.in
+++ b/requirements.in
@@ -39,7 +39,7 @@ multidict==6.4.4
 multiprocess==0.70.18
 mutagen==1.47.0
 networkx==3.4.2
-nltk==3.9.3
+nltk==3.10.0
 numpy<2.0
 openai>=2.20.0
 openpyxl==3.1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,9 @@ cymem==2.0.13
 decorator==4.4.2
     # via moviepy
 defusedxml==0.7.1
-    # via py-serializable
+    # via
+    #   nltk
+    #   py-serializable
 dill==0.4.0
     # via
     #   mega-rag-chatbot
@@ -290,7 +292,7 @@ mutagen==1.47.0
     # via mega-rag-chatbot
 networkx==3.4.2
     # via mega-rag-chatbot
-nltk==3.9.4
+nltk==3.10.0
     # via mega-rag-chatbot
 numpy==2.4.3
     # via

--- a/reranking/pyproject.toml
+++ b/reranking/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 requires-python = ">=3.11,<3.12"
 dependencies = [
     "filelock>=3.20.1",
-    "nltk==3.9.4",
+    "nltk==3.10.0",
     "numpy>=2.0,<3.0",
     "onnx>=1.22.0",
     "openai>=2.20.0",

--- a/reranking/requirements.txt
+++ b/reranking/requirements.txt
@@ -26,6 +26,8 @@ cuda-pathfinder==1.5.0 ; sys_platform == 'linux'
     # via cuda-bindings
 cuda-toolkit==13.0.2 ; sys_platform == 'linux'
     # via torch
+defusedxml==0.7.1
+    # via nltk
 distro==1.9.0
     # via openai
 filelock==3.25.2
@@ -74,7 +76,7 @@ mpmath==1.3.0
     # via sympy
 networkx==3.4.2
     # via torch
-nltk==3.9.4
+nltk==3.10.0
     # via mega-rag-chatbot-reranking
 numpy==2.4.3
     # via

--- a/security/accepted-vulns.yaml
+++ b/security/accepted-vulns.yaml
@@ -158,20 +158,6 @@ python:
     review_by: "2026-10-07"
     mitigation: "Dormant reranking subgraph; not deployed in production."
 
-  - id: PYSEC-2026-597
-    package: nltk
-    reason: >-
-      No fixed PyPI release reported by pip-audit (Dependabot also reports no
-      patched version for GHSA-p4gq-832x-fm9v / CVE-2026-54293). nltk 3.10.0
-      exists but is held under the 7-day cooldown and is not confirmed as the
-      advisory fix. Path traversal is in nltk.data.load() URL-encoded paths;
-      ingestion uses trusted local corpora, not attacker-controlled remote
-      resource URLs.
-    review_by: "2026-07-20"
-    mitigation: >-
-      Revisit after 2026-07-15 when nltk 3.10.0 clears cooldown; confirm whether
-      it addresses CVE-2026-54293 before adopting.
-
 node:
   - id: "1117038"
     package: showdown

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "2026-07-06T17:50:32.892494Z"
+exclude-newer = "2026-07-09T22:25:08.642619Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -1439,7 +1439,7 @@ requires-dist = [
     { name = "multiprocess", specifier = "==0.70.18" },
     { name = "mutagen", specifier = "==1.47.0" },
     { name = "networkx", specifier = "==3.4.2" },
-    { name = "nltk", specifier = "==3.9.4" },
+    { name = "nltk", specifier = "==3.10.0" },
     { name = "numpy", specifier = ">=2.0,<3.0" },
     { name = "openai", specifier = ">=2.20.0" },
     { name = "openpyxl", specifier = "==3.1.5" },
@@ -1558,7 +1558,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "filelock", specifier = ">=3.20.1" },
-    { name = "nltk", specifier = "==3.9.4" },
+    { name = "nltk", specifier = "==3.10.0" },
     { name = "numpy", specifier = ">=2.0,<3.0" },
     { name = "onnx", specifier = ">=1.22.0" },
     { name = "openai", specifier = ">=2.20.0" },
@@ -1735,17 +1735,18 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.9.4"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "defusedxml" },
     { name = "joblib" },
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `nltk` from 3.9.4 → **3.10.0** (published 2026-07-08; past 7-day cooldown) via targeted `uv lock --upgrade-package nltk` + export.
- Remove `PYSEC-2026-597` from `security/accepted-vulns.yaml` — pip-audit no longer reports it after the bump.
- Replaces closed Dependabot #159 (uv-group export drift).

## Test plan
- [x] `uv lock --upgrade-package nltk`
- [x] `bin/export-python-requirements.sh`
- [x] `./bin/run-pip-audit.sh` — 0 blocking findings (`severity>=high`)
- [ ] CI Monorepo + Comprehensive Test Suite green


Made with [Cursor](https://cursor.com)