### PR TITLE
fix: outlast GTM-gated Intercom boot in hide-intercom poll

### DIFF
--- a/wordpress/plugins/ananda-ai-chatbot/assets/js/chatbot.js
+++ b/wordpress/plugins/ananda-ai-chatbot/assets/js/chatbot.js
@@ -734,10 +734,14 @@ function initChatbot() {
     intercomEnabled = aichatbotData.enableIntercom === "1";
 
     // If the intercom integration is enabled, we need to wait for the Intercom object to be available
-    // So we check every 500ms if the Intercom object is available
+    // So we check every 500ms if the Intercom object is available.
+    // The budget has to outlast Intercom's own arrival: on ananda.org it now boots
+    // from Google Tag Manager on DOM Ready, so window.Intercom appears only after
+    // gtm.js has loaded. If we give up first, hide-intercom is never applied and
+    // Intercom's own launcher shows up next to the chatbot bubble.
     if (intercomEnabled) {
       let attempts = 0;
-      const maxAttempts = 10; // 5 seconds total (10 attempts * 500ms)
+      const maxAttempts = 40; // 20 seconds total (40 attempts * 500ms)
       const checkInterval = 500; // 500ms = half second
 
       const setupIntercom = () => {


### PR DESCRIPTION
## Why

ananda.org just migrated its Intercom loader out of the `ananda-org` child theme and into Google Tag Manager (anandaworldwide/ananda-org#92, theme 1.13.0, live now). Previously `window.Intercom` was defined by a `wp_footer` inline snippet during page parsing — effectively always present before `initChatbot()` ran. It is now defined by a GTM Custom HTML tag firing on **DOM Ready**, so its arrival is gated behind async `gtm.js`.

That makes this plugin's Intercom poll the tight spot:

```js
const maxAttempts = 10; // 5 seconds total (10 attempts * 500ms)
```

If the budget expires before Intercom arrives, `setupIntercom()` never runs, so **`hide-intercom` is never added to `<body>`** — and the CSS that hides Intercom's own launcher (`body.hide-intercom .intercom-lightweight-app-launcher, …`) never applies. The visitor then sees Intercom's launcher *and* the chatbot bubble at the same time, and the chatbot's hand-off (`showIntercom()`) is out of sync with what's on screen.

## What changed

One constant plus a comment explaining the dependency — 20s instead of 5s:

```js
const maxAttempts = 40; // 20 seconds total (40 attempts * 500ms)
```

No version bump: consistent with be86814e ("make chatbot.js delay-proof for JS-delay optimizers"), which likewise touched only `chatbot.js`.

## Verification

Measured on a normal production load of `/meditation/`: `chatbot.js` executes ≈2179ms, GTM defines the stub at DOM Ready ≈2914ms — ~4.3s of headroom inside the old 5s budget. Fine on a fast connection, but a slow mobile connection, a consent delay, or a slow container eats it.

Reproduced the failure against production by aborting `googletagmanager.com` for the page load, waiting 9s (past the old budget), then running the exact GTM tag payload: `intercom-enabled` false, `hide-intercom` false, **Intercom launcher visible at 48×48 next to the chatbot bubble**. With a 20s budget that window closes.

`node --check` passes. The polling loop itself is unchanged — it still stops on first success, so on a normal load this costs nothing.

## Note for whoever owns the Intercom setup

Separately, Intercom is now blocked whenever GTM is blocked (verified: with `googletagmanager.com` aborted, `window.Intercom` stays undefined and the hand-off silently no-ops while the bubble still shows). Most blocklists that block GTM also list `widget.intercom.io`, so the affected population is probably small — flagging it rather than proposing a change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)